### PR TITLE
Namespace generated enum members with the name of the enum.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ Header:
 ```C
 // Some boilerplate omitted.
 typedef enum Colours {
-        Red = -6,
-        Blue,
-        Green = 7,
-        Yellow,
+        Colours_Red = -6,
+        Colours_Blue,
+        Colours_Green = 7,
+        Colours_Yellow,
 } Colours;
 // Some more boilerplate omitted.
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,10 +136,10 @@
 //! ```C
 //! // Some boilerplate omitted.
 //! typedef enum Colours {
-//!         Red = -6,
-//!         Blue,
-//!         Green = 7,
-//!         Yellow,
+//!         Colours_Red = -6,
+//!         Colours_Blue,
+//!         Colours_Green = 7,
+//!         Colours_Yellow,
 //! } Colours;
 //! // Some more boilerplate omitted.
 //! ```

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -186,7 +186,7 @@ fn parse_enum(item: &ast::Item) -> Result<Option<String>, Error> {
             let (_, docs) = parse_attr(&var.node.attrs, |_| true, |attr| retrieve_docstring(attr, "\t"));
             buffer.push_str(&docs);
 
-            buffer.push_str(&format!("\t{},\n", print::pprust::variant_to_string(var)));
+            buffer.push_str(&format!("\t{}_{},\n", name, print::pprust::variant_to_string(var)));
         }
     } else {
         return Err(Error {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -120,18 +120,18 @@ cheddar_cmp_test! { test_compilable_typedefs,
 cheddar_cmp_test! { test_compilable_enums,
     "
     typedef enum Colours {
-        Red,
-        Orange,
-        Yellow,
-        Green,
-        Blue,
-        Indigo,
-        Violet,
+        Colours_Red,
+        Colours_Orange,
+        Colours_Yellow,
+        Colours_Green,
+        Colours_Blue,
+        Colours_Indigo,
+        Colours_Violet,
     } Colours;
 
     typedef enum TypesOfLabrador {
-        Stupid = -8,
-        Braindead,
+        TypesOfLabrador_Stupid = -8,
+        TypesOfLabrador_Braindead,
     } TypesOfLabrador;
     ",
     "
@@ -409,9 +409,9 @@ cheddar_cmp_test! { test_general_interplay,
     typedef float Ins;
 
     typedef enum Eye {
-        Blue = -1,
-        Green,
-        Red,
+        Eye_Blue = -1,
+        Eye_Green,
+        Eye_Red,
     } Eye;
 
     typedef struct Person {


### PR DESCRIPTION
Rust enum members are namespaced by the enum, whereas C enum members leak into the containing namespace.  This makes constructs such as:

```
#[repr(C)]
pub enum Foo {
    WIN = 1,
    LOSE = 2,
}

#[repr(C)]
pub enum Bar {
    WIN = 3,
    LOSE = 4,
}
```

...ambiguous within C when they're valid in Rust.  The solution offered in this PR is to prefix the enum members with the enum's name to provide a form of namespacing.

I'm not sure if you'd merge this as-is because it breaks compatibility with existing output
