### PR TITLE
Support std::os::raw variants of libc types.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,9 +263,11 @@
 //! behind an opaque struct. This is because the C compiler must know the layout of the type and
 //! rusty-cheddar can not yet search other modules.
 //!
-//! The very important exception to this rule is `libc`, types used from `libc` _must_ be qualified
-//! (e.g. `libc::c_void`) so that they can be converted properly.
-//!
+//! The very important exception to this rule are the C ABI types defined in
+//! the `libc` crate and `std::os::raw`. Types from these two modules _must_
+//! be fully qualified (e.g. `libc::c_void` or `std::os::raw::c_longlong)
+//! so that they can be converted properly. Importing them with a `use`
+//! statement will not work.
 //!
 //! [the cargo docs]: http://doc.crates.io/build-script.html
 //! [repo]: https://github.com/Sean1708/rusty-cheddar

--- a/src/types.rs
+++ b/src/types.rs
@@ -154,14 +154,14 @@ fn path_to_c(path: &ast::Path) -> Result<Option<String>, Error> {
             .expect("already checked that there were at least two elements")
             .identifier.name.as_str();
 
-        if module != "libc" {
-            Err(Error {
-                level: Level::Error,
-                span: Some(path.span),
-                message: "cheddar can not handle types in other modules (except `libc`)".into(),
-            })
-        } else {
-            Ok(Some(libc_ty_to_c(ty).into()))
+        match module {
+            "libc" => Ok(Some(libc_ty_to_c(ty).into())),
+            "std::os::raw" => Ok(Some(osraw_ty_to_c(ty).into())),
+            _ => Err(Error {
+                    level: Level::Error,
+                    span: Some(path.span),
+                    message: "cheddar can not handle types in other modules (except `libc`)".into(),
+            }),
         }
     } else {
         Ok(Some(rust_ty_to_c(&path.segments[0].identifier.name.as_str()).into()))
@@ -187,6 +187,30 @@ fn libc_ty_to_c(ty: &str) -> &str {
         "c_ulong" => "unsigned long",
         "c_longlong" => "long long",
         "c_ulonglong" => "unsigned long long",
+        // All other types should map over to C.
+        ty => ty,
+    }
+}
+
+/// Convert a Rust type from `std::os::raw` into a C type.
+///
+/// These mostly mirror the libc crate.
+fn osraw_ty_to_c(ty: &str) -> &str {
+    match ty {
+        "c_void" => "void",
+        "c_char" => "char",
+        "c_double" => "double",
+        "c_float" => "float",
+        "c_int" => "int",
+        "c_long" => "long",
+        "c_longlong" => "long long",
+        "c_schar" => "signed char",
+        "c_short" => "short",
+        "c_uchar" => "unsigned char",
+        "c_uint" => "unsigned int",
+        "c_ulong" => "unsigned long",
+        "c_ulonglong" => "unsigned long long",
+        "c_ushort" => "unsigned short",
         // All other types should map over to C.
         ty => ty,
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -362,6 +362,40 @@ cheddar_cmp_test! { test_libc_types,
     "
 }
 
+cheddar_cmp_test! { test_os_raw_types,
+    "
+    typedef void CVoid;
+    typedef char CChar;
+    typedef double CDouble;
+    typedef float CFloat;
+    typedef int CInt;
+    typedef long CLong;
+    typedef long long CLongLong;
+    typedef signed char CSChar;
+    typedef short CShort;
+    typedef unsigned char CUChar;
+    typedef unsigned int CUInt;
+    typedef unsigned long CULong;
+    typedef unsigned long long CULongLong;
+    typedef unsigned short CUShort;
+    ",
+    "
+    pub type CVoid = std::os::raw::c_void;
+    pub type CChar = std::os::raw::c_char;
+    pub type CDouble = std::os::raw::c_double;
+    pub type CFloat = std::os::raw::c_float;
+    pub type CInt = std::os::raw::c_int;
+    pub type CLong = std::os::raw::c_long;
+    pub type CLongLong = std::os::raw::c_longlong;
+    pub type CSChar = std::os::raw::c_schar;
+    pub type CShort = std::os::raw::c_short;
+    pub type CUChar = std::os::raw::c_uchar;
+    pub type CUInt = std::os::raw::c_uint;
+    pub type CULong = std::os::raw::c_ulong;
+    pub type CULongLong = std::os::raw::c_ulonglong;
+    pub type CUShort = std::os::raw::c_ushort;
+    "
+}
 cheddar_cmp_test! { test_module, api "api",
     "
     typedef float Float;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -396,6 +396,7 @@ cheddar_cmp_test! { test_os_raw_types,
     pub type CUShort = std::os::raw::c_ushort;
     "
 }
+
 cheddar_cmp_test! { test_module, api "api",
     "
     typedef float Float;


### PR DESCRIPTION
Until the libc crate becomes part of the stable toolchain,
it's nice to have these versions work too for situations
where external crate dependencies are difficult.