### PR TITLE
Test cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,9 +263,11 @@
 //! behind an opaque struct. This is because the C compiler must know the layout of the type and
 //! rusty-cheddar can not yet search other modules.
 //!
-//! The very important exception to this rule is `libc`, types used from `libc` _must_ be qualified
-//! (e.g. `libc::c_void`) so that they can be converted properly.
-//!
+//! The very important exception to this rule are the C ABI types defined in
+//! the `libc` crate and `std::os::raw`. Types from these two modules _must_
+//! be fully qualified (e.g. `libc::c_void` or `std::os::raw::c_longlong)
+//! so that they can be converted properly. Importing them with a `use`
+//! statement will not work.
 //!
 //! [the cargo docs]: http://doc.crates.io/build-script.html
 //! [repo]: https://github.com/Sean1708/rusty-cheddar

--- a/src/types.rs
+++ b/src/types.rs
@@ -154,14 +154,14 @@ fn path_to_c(path: &ast::Path) -> Result<Option<String>, Error> {
             .expect("already checked that there were at least two elements")
             .identifier.name.as_str();
 
-        if module != "libc" {
-            Err(Error {
-                level: Level::Error,
-                span: Some(path.span),
-                message: "cheddar can not handle types in other modules (except `libc`)".into(),
-            })
-        } else {
-            Ok(Some(libc_ty_to_c(ty).into()))
+        match module {
+            "libc" => Ok(Some(libc_ty_to_c(ty).into())),
+            "std::os::raw" => Ok(Some(osraw_ty_to_c(ty).into())),
+            _ => Err(Error {
+                    level: Level::Error,
+                    span: Some(path.span),
+                    message: "cheddar can not handle types in other modules (except `libc`)".into(),
+            }),
         }
     } else {
         Ok(Some(rust_ty_to_c(&path.segments[0].identifier.name.as_str()).into()))
@@ -187,6 +187,30 @@ fn libc_ty_to_c(ty: &str) -> &str {
         "c_ulong" => "unsigned long",
         "c_longlong" => "long long",
         "c_ulonglong" => "unsigned long long",
+        // All other types should map over to C.
+        ty => ty,
+    }
+}
+
+/// Convert a Rust type from `std::os::raw` into a C type.
+///
+/// These mostly mirror the libc crate.
+fn osraw_ty_to_c(ty: &str) -> &str {
+    match ty {
+        "c_void" => "void",
+        "c_char" => "char",
+        "c_double" => "double",
+        "c_float" => "float",
+        "c_int" => "int",
+        "c_long" => "long",
+        "c_longlong" => "long long",
+        "c_schar" => "signed char",
+        "c_short" => "short",
+        "c_uchar" => "unsigned char",
+        "c_uint" => "unsigned int",
+        "c_ulong" => "unsigned long",
+        "c_ulonglong" => "unsigned long long",
+        "c_ushort" => "unsigned short",
         // All other types should map over to C.
         ty => ty,
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -157,7 +157,6 @@ fn path_to_c(path: &ast::Path) -> Result<Option<String>, Error> {
             segments.push(String::from(&*segment.identifier.name.as_str()));
         }
         let module = segments.join("::");
-        println!("Checking type {} in module {}...", ty, module);
         match &*module {
             "libc" => Ok(Some(libc_ty_to_c(ty).into())),
             "std::os::raw" => Ok(Some(osraw_ty_to_c(ty).into())),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -362,6 +362,40 @@ cheddar_cmp_test! { test_libc_types,
     "
 }
 
+cheddar_cmp_test! { test_os_raw_types,
+    "
+    typedef void CVoid;
+    typedef char CChar;
+    typedef double CDouble;
+    typedef float CFloat;
+    typedef int CInt;
+    typedef long CLong;
+    typedef long long CLongLong;
+    typedef signed char CSChar;
+    typedef short CShort;
+    typedef unsigned char CUChar;
+    typedef unsigned int CUInt;
+    typedef unsigned long CULong;
+    typedef unsigned long long CULongLong;
+    typedef unsigned short CUShort;
+    ",
+    "
+    pub type CVoid = std::os::raw::c_void;
+    pub type CChar = std::os::raw::c_char;
+    pub type CDouble = std::os::raw::c_double;
+    pub type CFloat = std::os::raw::c_float;
+    pub type CInt = std::os::raw::c_int;
+    pub type CLong = std::os::raw::c_long;
+    pub type CLongLong = std::os::raw::c_longlong;
+    pub type CSChar = std::os::raw::c_schar;
+    pub type CShort = std::os::raw::c_short;
+    pub type CUChar = std::os::raw::c_uchar;
+    pub type CUInt = std::os::raw::c_uint;
+    pub type CULong = std::os::raw::c_ulong;
+    pub type CULongLong = std::os::raw::c_ulonglong;
+    pub type CUShort = std::os::raw::c_ushort;
+    "
+}
 cheddar_cmp_test! { test_module, api "api",
     "
     typedef float Float;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,8 +3,8 @@ extern crate cheddar;
 use std::process::Command;
 
 macro_rules! inner_cheddar_cmp_test {
-    ($name:ident, $compile:expr, $header:expr) => {
-        #[test]
+    ($name:ident, $(#[$attr:meta])*, $compile:expr, $header:expr) => {
+        $(#[$attr])*
         fn $name() {
             let expected = $header;
 
@@ -79,7 +79,7 @@ macro_rules! inner_cheddar_cmp_test {
 macro_rules! cheddar_cmp_test {
     ($name:ident, custom $custom:expr, $header:expr, $rust:expr) => {
         inner_cheddar_cmp_test! {
-            $name,
+            $name, #[test],
             cheddar::Cheddar::new().unwrap().source_string($rust).insert_code($custom).compile_code(),
             $header
         }
@@ -87,15 +87,23 @@ macro_rules! cheddar_cmp_test {
 
     ($name:ident, api $api:expr, $header:expr, $rust:expr) => {
         inner_cheddar_cmp_test! {
-            $name,
+            $name, #[test],
             cheddar::Cheddar::new().unwrap().source_string($rust).module($api).unwrap().compile_code(),
+            $header
+        }
+    };
+
+    ($name:ident, xfail, $header:expr, $rust:expr) => {
+        inner_cheddar_cmp_test! {
+            $name, #[test] #[should_panic],
+            cheddar::Cheddar::new().unwrap().source_string($rust).compile_code(),
             $header
         }
     };
 
     ($name:ident, $header:expr, $rust:expr) => {
         inner_cheddar_cmp_test! {
-            $name,
+            $name, #[test],
             cheddar::Cheddar::new().unwrap().source_string($rust).compile_code(),
             $header
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -113,7 +113,7 @@ macro_rules! cheddar_cmp_test {
 
 
 
-cheddar_cmp_test! { test_compilable_typedefs,
+cheddar_cmp_test! { compilable_typedefs,
     "
     typedef int64_t Int64;
     ",
@@ -126,7 +126,7 @@ cheddar_cmp_test! { test_compilable_typedefs,
     "
 }
 
-cheddar_cmp_test! { test_compilable_enums,
+cheddar_cmp_test! { compilable_enums,
     "
     typedef enum Colours {
         Red,
@@ -187,7 +187,7 @@ cheddar_cmp_test! { test_compilable_enums,
     "
 }
 
-cheddar_cmp_test! { test_compilable_structs,
+cheddar_cmp_test! { compilable_structs,
     "
     typedef struct Student {
         int32_t id;
@@ -220,7 +220,7 @@ cheddar_cmp_test! { test_compilable_structs,
     "
 }
 
-cheddar_cmp_test! { test_opaque_structs,
+cheddar_cmp_test! { opaque_structs,
     "
     typedef struct Foo Foo;
     ",
@@ -230,7 +230,7 @@ cheddar_cmp_test! { test_opaque_structs,
     "
 }
 
-cheddar_cmp_test! { test_compilable_functions,
+cheddar_cmp_test! { compilable_functions,
     "
     int64_t add_i64(int64_t lhs, int64_t rhs);
     ",
@@ -260,7 +260,7 @@ cheddar_cmp_test! { test_compilable_functions,
     "#
 }
 
-cheddar_cmp_test! { test_compilable_function_pointers,
+cheddar_cmp_test! { compilable_function_pointers,
     "
     typedef const int32_t** (*TwoIntPtrFnPtr)(double* argument);
 
@@ -288,7 +288,7 @@ cheddar_cmp_test! { test_compilable_function_pointers,
     "#
 }
 
-cheddar_cmp_test! { test_pure_rust_types,
+cheddar_cmp_test! { pure_rust_types,
     "
     typedef void MyVoid;
     typedef float Float32;
@@ -331,7 +331,7 @@ cheddar_cmp_test! { test_pure_rust_types,
     "
 }
 
-cheddar_cmp_test! { test_libc_types,
+cheddar_cmp_test! { libc_types,
     "
     typedef void CVoid;
     typedef float CFloat;
@@ -371,7 +371,7 @@ cheddar_cmp_test! { test_libc_types,
     "
 }
 
-cheddar_cmp_test! { test_os_raw_types,
+cheddar_cmp_test! { std_os_raw_types,
     "
     typedef void CVoid;
     typedef char CChar;
@@ -407,7 +407,7 @@ cheddar_cmp_test! { test_os_raw_types,
 }
 
 // Verify we don't accept module types without a full prefix.
-cheddar_cmp_test! { test_module_no_prefix, xfail,
+cheddar_cmp_test! { module_no_prefix, xfail,
     "
     typedef CVoid void;
     ",
@@ -421,7 +421,7 @@ cheddar_cmp_test! { test_module_no_prefix, xfail,
 }
 
 
-cheddar_cmp_test! { test_module, api "api",
+cheddar_cmp_test! { module, api "api",
     "
     typedef float Float;
     ",
@@ -433,7 +433,7 @@ cheddar_cmp_test! { test_module, api "api",
     "
 }
 
-cheddar_cmp_test! { test_inside_module, api "c::api",
+cheddar_cmp_test! { inside_module, api "c::api",
     "
     typedef float Float;
     ",
@@ -447,7 +447,7 @@ cheddar_cmp_test! { test_inside_module, api "c::api",
     "
 }
 
-cheddar_cmp_test! { test_custom,
+cheddar_cmp_test! { custom,
     custom "
     typedef F64 MyF64;
     ",
@@ -460,7 +460,7 @@ cheddar_cmp_test! { test_custom,
     "
 }
 
-cheddar_cmp_test! { test_general_interplay,
+cheddar_cmp_test! { general_interplay,
     "
     typedef float Kg;
     typedef float Lbs;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -396,6 +396,7 @@ cheddar_cmp_test! { test_os_raw_types,
     pub type CUShort = std::os::raw::c_ushort;
     "
 }
+
 cheddar_cmp_test! { test_module, api "api",
     "
     typedef float Float;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -406,6 +406,21 @@ cheddar_cmp_test! { test_os_raw_types,
     "
 }
 
+// Verify we don't accept module types without a full prefix.
+cheddar_cmp_test! { test_module_no_prefix, xfail,
+    "
+    typedef CVoid void;
+    ",
+    "
+    extern crate libc;
+    use libc::FILE;
+    use std::os::raw;
+    pub type CVoid = raw::c_void;
+    pub type CFile = FILE;
+    "
+}
+
+
 cheddar_cmp_test! { test_module, api "api",
     "
     typedef float Float;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,7 +3,8 @@ extern crate cheddar;
 use std::process::Command;
 
 macro_rules! inner_cheddar_cmp_test {
-    ($name:ident, $(#[$attr:meta])*, $compile:expr, $header:expr) => {
+    ($name:ident $(#[$attr:meta])*, $compile:expr, $header:expr) => {
+        #[test]
         $(#[$attr])*
         fn $name() {
             let expected = $header;
@@ -79,7 +80,7 @@ macro_rules! inner_cheddar_cmp_test {
 macro_rules! cheddar_cmp_test {
     ($name:ident, custom $custom:expr, $header:expr, $rust:expr) => {
         inner_cheddar_cmp_test! {
-            $name, #[test],
+            $name,
             cheddar::Cheddar::new().unwrap().source_string($rust).insert_code($custom).compile_code(),
             $header
         }
@@ -87,7 +88,7 @@ macro_rules! cheddar_cmp_test {
 
     ($name:ident, api $api:expr, $header:expr, $rust:expr) => {
         inner_cheddar_cmp_test! {
-            $name, #[test],
+            $name,
             cheddar::Cheddar::new().unwrap().source_string($rust).module($api).unwrap().compile_code(),
             $header
         }
@@ -95,7 +96,7 @@ macro_rules! cheddar_cmp_test {
 
     ($name:ident, xfail, $header:expr, $rust:expr) => {
         inner_cheddar_cmp_test! {
-            $name, #[test] #[should_panic],
+            $name #[should_panic],
             cheddar::Cheddar::new().unwrap().source_string($rust).compile_code(),
             $header
         }
@@ -103,7 +104,7 @@ macro_rules! cheddar_cmp_test {
 
     ($name:ident, $header:expr, $rust:expr) => {
         inner_cheddar_cmp_test! {
-            $name, #[test],
+            $name,
             cheddar::Cheddar::new().unwrap().source_string($rust).compile_code(),
             $header
         }


### PR DESCRIPTION
Some misc further work on the tests on top of my osraw pr #36.

- Allow xfail tests for enforcing code rejection. This isn't ideal in that a lot of errors could shadow others, but I thought it was helpful enough to add.
- Add such a test for non-qualified `libc` and `std::os::raw` types.
- Remove redundant 'test' from the unit test names.